### PR TITLE
Links to City pages

### DIFF
--- a/app/views/homepage/cities.jade
+++ b/app/views/homepage/cities.jade
@@ -1,0 +1,18 @@
+#cities
+  h2 Cities we are in
+
+  ul
+    li
+      a(href='/pdx') Portland
+    li
+      a(href='/seattle') Seattle
+    li
+      a(href='/sf') San Francisco
+    li
+      a(href='/atx') Austin
+    li
+      a(href='/boston') Boston
+    li
+      a(href='/chicago') Chicago
+    li
+      a(href='/nyc') New York 

--- a/app/views/homepage/index.jade
+++ b/app/views/homepage/index.jade
@@ -11,6 +11,7 @@ block content
         img(src='/images/actw-background1.png')
 
         include about
+        include cities
         include sponsors
         include opportunities
         include organizers

--- a/app/views/homepage/navbar.jade
+++ b/app/views/homepage/navbar.jade
@@ -5,6 +5,8 @@
       li
         a(href='#about') About
       li
+        a(href='#cities') Cities
+      li
         a(href='#sponsors') Sponsors
       li
         a(href='#opportunities') Opportunities


### PR DESCRIPTION
Added in links to the different city pages, no styling applied.

We can change where they appear on the page once we figure out the design but they are under the about section for now.

Each city link should take you to corresponding city page.
